### PR TITLE
Add useNativeDriver prop for RN 0.62

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-tsconfig.json
-/src

--- a/src/SkeletonPlaceholder.tsx
+++ b/src/SkeletonPlaceholder.tsx
@@ -34,7 +34,8 @@ export default function SkeletonPlaceholder({
       Animated.timing(animatedValue, {
         toValue: 1,
         duration: speed,
-        easing: Easing.ease
+        easing: Easing.ease,
+        useNativeDriver: true,
       })
     ).start();
   });


### PR DESCRIPTION
Hey,

On current version of React Native (0.62) I got warnings after every cycle: 

> Animated: `useNativeDriver` was not specified. This is a required option and must be explicitly set to `true` or `false` 

This little fix helped me, pls. add it.
Thanks.