### PR TITLE
Fix ./lib/SkeletonPlaceholder.js not found in JS projects

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,6 @@
  * @repo
  */
 
-const SkeletonPlaceholder = require("./lib/SkeletonPlaceholder");
+const SkeletonPlaceholder = require("./src/SkeletonPlaceholder");
 
 export default SkeletonPlaceholder;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-skeleton-placeholder",
   "version": "4.0.0",
   "description": "SkeletonPlaceholder is a React Native library to easily create an amazing loading effect.",
-  "main": "lib/SkeletonPlaceholder.js",
+  "main": "src/SkeletonPlaceholder.tsx",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rm -rf ./lib && mkdir ./lib && tsc"


### PR DESCRIPTION
Using JS projects, after install and run commnad `react-native run-android`, an error occurs:

While trying to resolve module react-native-skeleton-placeholder from file xxxxx, the package /node_modules/react-native-skeleton-placeholder/package.json was successfully found. However, this package itself specifies a main module field that could not be resolved (/node_modules/react-native-skeleton-placeholder/lib/SkeletonPlaceholder.js. Indeed, none of these files exist:

/node_modules/react-native-skeleton-placeholder/lib/SkeletonPlaceholder.js(.native|.ios.js|.native.js|.js|.ios.json|.native.json|.json|.ios.ts|.native.ts|.ts|.ios.tsx|.native.tsx|.tsx)
/node_modules/react-native-skeleton-placeholder/lib/SkeletonPlaceholder.js/index(.native|.ios.js|.native.js|.js|.ios.json|.native.json|.json|.ios.ts|.native.ts|.ts|.ios.tsx|.native.tsx|.tsx)
at DependencyGraph.resolveDependency (/node_modules/metro/src/node-haste/DependencyGraph.js:376:17)