### PR TITLE
fix: Preserve `testID`

### DIFF
--- a/src/SkeletonPlaceholder.tsx
+++ b/src/SkeletonPlaceholder.tsx
@@ -102,13 +102,17 @@ export default function SkeletonPlaceholder({
           }
           if (child.props.children) {
             return (
-              <View key={index} style={style}>
+              <View key={index} style={style} testID={child.props.testID}>
                 {getChildren(child.props.children)}
               </View>
             );
           } else {
             return (
-              <View key={index} style={styles.childContainer}>
+              <View
+                key={index}
+                style={styles.childContainer}
+                testID={child.props.testID}
+              >
                 <View style={[style, viewStyle]} />
               </View>
             );


### PR DESCRIPTION
Currently [react-native-skeleton-placeholder](https://github.com/chramos/react-native-skeleton-placeholder) does not support `testID` being passed to its children. In order to preserve this - I've added a small prop addition to the `getChildren` method. 