### PR TITLE
Removes the style requirement on the item

### DIFF
--- a/src/SkeletonPlaceholder.tsx
+++ b/src/SkeletonPlaceholder.tsx
@@ -50,7 +50,7 @@ type SkeletonPlaceholderProps = {
 };
 
 type SkeletonPlaceholderItemProps = ViewStyle & {
-  style: StyleProp<ViewStyle>;
+  style?: StyleProp<ViewStyle>;
 };
 
 const SkeletonPlaceholder: React.FC<SkeletonPlaceholderProps> & {


### PR DESCRIPTION
Simple fix.
Because of the added type every item has to have an "empty" style for the typescript to stop complaining.

Example:
![Screen Shot 2022-10-13 at 10 30 17](https://user-images.githubusercontent.com/18687097/195610517-843437fe-5e31-40e3-bf63-0d611b3ab617.png)
