### PR TITLE
Update `main` script location in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-skeleton-placeholder",
   "version": "5.2.0",
   "description": "SkeletonPlaceholder is a React Native library to easily create an amazing loading effect.",
-  "main": "lib/SkeletonPlaceholder.js",
+  "main": "lib/skeleton-placeholder.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint . --max-warnings 0",


### PR DESCRIPTION
Fixes this build error after the module was renamed in 0285c8d70c099b9967a958ff9fba461b2d79a309


```
error While trying to resolve module `react-native-skeleton-placeholder` from file ..., the package `node_modules/react-native-skeleton-placeholder/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`node_modules/react-native-skeleton-placeholder/lib/SkeletonPlaceholder.js`.
```