### PR TITLE
Added shimmerWidth prop to configure Gradient component's width

### DIFF
--- a/src/skeleton-placeholder.tsx
+++ b/src/skeleton-placeholder.tsx
@@ -46,6 +46,10 @@ type SkeletonPlaceholderProps = {
    */
   borderRadius?: number;
   angle?: number;
+  /**
+   * Determines width of the highlighted area
+   */
+  shimmerWidth?: number;
 };
 
 type SkeletonPlaceholderItemProps = ViewStyle & {
@@ -62,6 +66,7 @@ const SkeletonPlaceholder: React.FC<SkeletonPlaceholderProps> & {
   speed = 800,
   direction = 'right',
   borderRadius,
+  shimmerWidth,
 }) => {
   const [layout, setLayout] = React.useState<LayoutRectangle>();
   const animatedValueRef = React.useRef(new Animated.Value(0));
@@ -128,7 +133,7 @@ const SkeletonPlaceholder: React.FC<SkeletonPlaceholderProps> & {
       {isAnimationReady && highlightColor !== undefined && transparentColor !== undefined && (
         <Animated.View style={animatedGradientStyle}>
           <LinearGradient
-            {...gradientProps}
+            {...getGradientProps(shimmerWidth)}
             colors={[transparentColor, highlightColor, transparentColor]}
           />
         </Animated.View>
@@ -140,11 +145,11 @@ const SkeletonPlaceholder: React.FC<SkeletonPlaceholderProps> & {
 SkeletonPlaceholder.Item = (props) => <View style={getItemStyle(props)}>{props.children}</View>;
 SkeletonPlaceholder.Item.displayName = 'SkeletonPlaceholderItem';
 
-const gradientProps = {
+const getGradientProps = (width) => ({
   start: {x: 0, y: 0},
   end: {x: 1, y: 0},
-  style: StyleSheet.absoluteFill,
-};
+  style: {...StyleSheet.absoluteFillObject, width},
+});
 
 const getItemStyle = ({
   children: _,


### PR DESCRIPTION
Our designer wanted to make highlighted shimmer part more narrow, so I added 'shimmerWidth' prop that is passed to 'Gradient' style prop to be able to configure it. 