### PR TITLE
fix: update peerDependencies to support React 19 for Expo SDK 53 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "5.0.4"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
+    "react": "^18.0.0 || ^19.0.0",
     "react-native": ">=0.72.9",
     "react-native-reanimated": "^3.15.1",
     "react-native-svg": "^14.1.0"


### PR DESCRIPTION
## Summary

This PR updates the `peerDependencies` of `react-native-skeleton-placeholder` to allow usage with both React 18 and 19, resolving installation issues when using Expo SDK 53, which defaults to React 19. Fix #149

## Background

After upgrading to Expo SDK 53 (React Native 0.73), which uses React 19 by default, the current `peerDependencies` in version `6.0.0-beta.9` cause npm installation errors due to the strict `react@"^18.0.0"` requirement.

```

npm ERR! Could not resolve dependency:
npm ERR! peer react@"^18.0.0" from react-native-skeleton-placeholder\@6.0.0-beta.9

````

## Change Details

In `package.json`, the `peerDependencies.react` field is updated from:

```json
"react": "^18.0.0"
````

to:

```json
"react": "^18.0.0 || ^19.0.0"
```

This ensures compatibility with both React 18 and 19 environments without introducing breaking changes for existing users.
