### PR TITLE
feat: support custom LinearGradient component via prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Android and iOS
 
 ### Installation
 
-> Note: This package requires **@react-native-masked-view/masked-view** and **react-native-linear-gradient**
+> Note: This package requires **@react-native-masked-view/masked-view** and **react-native-linear-gradient** (or any compatible linear gradient library passed via the `LinearGradient` prop)
 
 ###### Step #1
 
@@ -106,14 +106,30 @@ const App = () => {
 
 #### SkeletonPlaceholder
 
-|      Prop       |                             Description                              |       Type        |  Default  |
-| :-------------: | :------------------------------------------------------------------: | :---------------: | :-------: |
-| backgroundColor |                 Determines the color of placeholder                  |    string       | _#E1E9EE_ |
-| highlightColor  |            Determines the highlight color of placeholder             |   string (hex \| rgb \| rgba)    | _#F2F8FC_ |
-|      speed      | Determines the animation speed in milliseconds. 0 disables animation |      number       |   _800_   |
-|    direction    |                  Determines the animation direction                  | "right" \| "left" |  "right"  |
-|     enabled     |   Determines if Skeleton should show placeholders or its children    |      boolean      |   true    |
-|  borderRadius   |          Determines default border radius for placeholders           |      number       | undefined |
+|      Prop       |                                                        Description                                                         |            Type             |           Default            |
+| :-------------: | :------------------------------------------------------------------------------------------------------------------------: | :-------------------------: | :--------------------------: |
+| backgroundColor |                                            Determines the color of placeholder                                             |           string            |          _#E1E9EE_           |
+| highlightColor  |                                       Determines the highlight color of placeholder                                        | string (hex \| rgb \| rgba) |          _#F2F8FC_           |
+|      speed      |                            Determines the animation speed in milliseconds. 0 disables animation                            |           number            |            _800_             |
+|    direction    |                                             Determines the animation direction                                             |      "right" \| "left"      |           "right"            |
+|     enabled     |                              Determines if Skeleton should show placeholders or its children                               |           boolean           |             true             |
+|  borderRadius   |                                     Determines default border radius for placeholders                                      |           number            |          undefined           |
+| LinearGradient  | A custom LinearGradient component, e.g. from `expo-linear-gradient`. Receives `colors`, `start`, `end`, and `style` props. |        ComponentType        | react-native-linear-gradient |
+
+#### Expo (expo-linear-gradient) usage
+
+If you are using Expo and want to use `expo-linear-gradient` instead of `react-native-linear-gradient`, pass it via the `LinearGradient` prop:
+
+```javascript
+import {LinearGradient} from 'expo-linear-gradient';
+import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
+
+const App = () => (
+  <SkeletonPlaceholder LinearGradient={LinearGradient}>
+    <SkeletonPlaceholder.Item width={120} height={20} />
+  </SkeletonPlaceholder>
+);
+```
 
 #### SkeletonPlaceholder.Item
 

--- a/package.json
+++ b/package.json
@@ -41,5 +41,10 @@
     "react": ">=0.14.8",
     "react-native": ">=0.50.1",
     "react-native-linear-gradient": "^2.5.6"
+  },
+  "peerDependenciesMeta": {
+    "react-native-linear-gradient": {
+      "optional": true
+    }
   }
 }

--- a/src/skeleton-placeholder.tsx
+++ b/src/skeleton-placeholder.tsx
@@ -10,11 +10,19 @@ import {
   View,
   ViewStyle,
 } from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
+import DefaultLinearGradient from 'react-native-linear-gradient';
 
 const WINDOW_WIDTH = Dimensions.get('window').width;
 
 const logEnabled = false;
+
+type LinearGradientProps = {
+  colors: (string | number)[];
+  start?: {x: number; y: number};
+  end?: {x: number; y: number};
+  style?: StyleProp<ViewStyle>;
+  [key: string]: any;
+};
 
 type SkeletonPlaceholderProps = {
   /**
@@ -50,6 +58,11 @@ type SkeletonPlaceholderProps = {
    * Determines width of the highlighted area
    */
   shimmerWidth?: number;
+  /**
+   * A custom LinearGradient component, e.g. from expo-linear-gradient.
+   * Defaults to react-native-linear-gradient.
+   */
+  LinearGradient?: React.ComponentType<LinearGradientProps>;
 };
 
 type SkeletonPlaceholderItemProps = ViewStyle & {
@@ -68,6 +81,7 @@ const SkeletonPlaceholder: React.FC<SkeletonPlaceholderProps> & {
   direction = 'right',
   borderRadius,
   shimmerWidth,
+  LinearGradient = DefaultLinearGradient,
 }) => {
   const [layout, setLayout] = React.useState<LayoutRectangle>();
   const animatedValueRef = React.useRef(new Animated.Value(0));
@@ -138,7 +152,7 @@ const SkeletonPlaceholder: React.FC<SkeletonPlaceholderProps> & {
         <Animated.View style={animatedGradientStyle}>
           <LinearGradient
             {...getGradientProps(shimmerWidth)}
-            colors={[transparentColor, highlightColor, transparentColor]}
+            colors={[transparentColor, highlightColor, transparentColor] as (string | number)[]}
           />
         </Animated.View>
       )}


### PR DESCRIPTION
## Problem
Users of Expo (or any other environment) cannot use this library out of the box
because it hardcodes `react-native-linear-gradient`, which is not compatible with
Expo's `expo-linear-gradient`.
## Solution
Accept a `LinearGradient` component as a prop, allowing users to pass any compatible
gradient library. Defaults to `react-native-linear-gradient` so existing usage is
fully backwards compatible.
## Usage (Expo)
```jsx
import { LinearGradient } from 'expo-linear-gradient';
import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
<SkeletonPlaceholder LinearGradient={LinearGradient}>
  <SkeletonPlaceholder.Item width={120} height={20} />
</SkeletonPlaceholder>
Changes
- src/skeleton-placeholder.tsx — added LinearGradient prop with react-native-linear-gradient as default
- package.json — marked react-native-linear-gradient as optional peer dependency
- README.md — documented the new prop and added Expo usage exampl