### PR TITLE
Update to absoluteFill because of removal of absoluteFillObject in RN 0.85.0

### DIFF
--- a/src/skeleton-placeholder.tsx
+++ b/src/skeleton-placeholder.tsx
@@ -91,7 +91,7 @@ const SkeletonPlaceholder: React.FC<SkeletonPlaceholderProps> & {
   const animatedGradientStyle = React.useMemo(() => {
     const animationWidth = WINDOW_WIDTH + (shimmerWidth ?? 0);
     return {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       flexDirection: 'row' as const,
       transform: [
         {
@@ -152,7 +152,7 @@ SkeletonPlaceholder.Item.displayName = 'SkeletonPlaceholderItem';
 const getGradientProps = (width) => ({
   start: {x: 0, y: 0},
   end: {x: 1, y: 0},
-  style: {...StyleSheet.absoluteFillObject, width},
+  style: {...StyleSheet.absoluteFill, width},
 });
 
 const getItemStyle = ({


### PR DESCRIPTION
StyleSheet.absoluteFillObject is still used in this library, but from RN 0.85.0 absoluteFillObject is removed. Because of this, animations can brake.
This fix replaces the StyleSheet.absoluteFillObject with StyleSheet.absoluteFill. 